### PR TITLE
better error handling for HTTP timeout

### DIFF
--- a/iotawattpy/connection.py
+++ b/iotawattpy/connection.py
@@ -43,5 +43,5 @@ class Connection:
             return resp
         except httpx.RequestError as e:
             LOGGER.error("An error occurred while requesting %s.", e.request.url)
-        except httpx.HTTPStatusError as exc:
+        except httpx.HTTPStatusError as e:
             LOGGER.error("Error response %s while requesting %s.", e.response.status_code, e.request.url)

--- a/iotawattpy/connection.py
+++ b/iotawattpy/connection.py
@@ -41,5 +41,7 @@ class Connection:
             # if decode_json:
             #    return (await resp.json())
             return resp
-        except httpx.HTTPError as err:
-            LOGGER.error("Err: %s", err)
+        except httpx.RequestError as e:
+            LOGGER.error("An error occurred while requesting %s.", e.request.url)
+        except httpx.HTTPStatusError as exc:
+            LOGGER.error("Error response %s while requesting %s.", e.response.status_code, e.request.url)

--- a/iotawattpy/connection.py
+++ b/iotawattpy/connection.py
@@ -41,7 +41,6 @@ class Connection:
             # if decode_json:
             #    return (await resp.json())
             return resp
-        except httpx.RequestError as e:
-            LOGGER.error("An error occurred while requesting %s.", e.request.url)
-        except httpx.HTTPStatusError as e:
-            LOGGER.error("Error response %s while requesting %s.", e.response.status_code, e.request.url)
+        except httpx.HTTPError as e:
+            LOGGER.debug(e.__doc__.strip())
+            raise e

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -73,7 +73,8 @@ class Iotawatt:
 
     async def update(self, timespan=30, lastUpdate=None):
         if not self._getMACFlag:
-            await self.connect()
+            if await self.connect() == None:
+                return False
             self._getMACFlag = True
         await self._refreshSensors(timespan, lastUpdate)
 
@@ -153,6 +154,8 @@ class Iotawatt:
         sensors = self._sensors["sensors"]
 
         response = await self._getInputsandOutputs()
+        if response == None:
+            return False
         results = response.text
         results = json.loads(results)
         LOGGER.debug("IOResults: %s", results)
@@ -160,6 +163,8 @@ class Iotawatt:
         outputs = results["outputs"]
 
         query = await self._getQueryShowSeries()
+        if query == None:
+            return False
         query = query.text
         query = json.loads(query)
         LOGGER.debug("Query: %s", query)
@@ -241,6 +246,8 @@ class Iotawatt:
         response = await self._getQuerySelectSeriesCurrent(
             current_query_names, timespan
         )
+        if response == None:
+            return False
         values = json.loads(response.text)
         LOGGER.debug("Val: %s", values)
 
@@ -257,6 +264,8 @@ class Iotawatt:
         response = await self._getQuerySelectSeriesIntegrate(
             integrated_total_query_names, self._integratedInterval
         )
+        if response == None:
+            return False
         values = json.loads(response.text)
         LOGGER.debug("Val: %s", values)
 
@@ -301,6 +310,8 @@ class Iotawatt:
             now.isoformat().split("+")[0] + "Z",
             precision=".d3",
         )
+        if response == None:
+            return False
         values = json.loads(response.text)
         LOGGER.debug("Val: %s", values)
 

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -45,6 +45,8 @@ class Iotawatt:
     async def connect(self):
         url = "http://{}/status?wifi=yes".format(self._ip)
         results = await self._connection.get(url, self._username, self._password)
+        if results == None:
+            return False
         if results.status_code == httpx.codes.OK:
             try:
                 jsonResults = results.json()


### PR DESCRIPTION
I'm no expert at `httpx` but I followed their [Quickstart guide](https://www.python-httpx.org/quickstart/#exceptions) for exception handling.  Now the errors look like this when IotaWatt is not responding in time.
```
2023-02-02 02:21:34.011 ERROR (MainThread) [iotawattpy.connection] An error occurred while requesting http://192.168.20.32/status?wifi=yes.
2023-02-02 02:21:34.013 DEBUG (MainThread) [homeassistant.components.iotawatt.coordinator] Finished fetching IotaWatt data in 5.011 seconds (success: False)
```

I'm totally open to feedback if there's a better way to fix this.

Fixes https://github.com/home-assistant-libs/iotawattpy/issues/1