### PR TITLE
Remove energy energy-over-period sensors: they cause issue for HA

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -140,15 +140,15 @@ class Iotawatt:
                 suffix=".wh",
                 fromStart=True,
             )
-            self._createOrUpdateSensor(
-                sensors,
-                entity + "_energy",
-                channel_nbr,
-                base_name,
-                type,
-                "WattHours",
-                suffix=".wh",
-            )
+            # self._createOrUpdateSensor(
+            #     sensors,
+            #     entity + "_energy",
+            #     channel_nbr,
+            #     base_name,
+            #     type,
+            #     "WattHours",
+            #     suffix=".wh",
+            # )
 
     async def _refreshSensors(self, timespan, lastUpdate):
         sensors = self._sensors["sensors"]
@@ -355,6 +355,8 @@ class Iotawatt:
         - d - The current day
         See also:https://docs.iotawatt.com/en/02_06_03/query.html#relative-time
         """
+        if not sensor_names:
+            return None
         url = "http://{}/query".format(self._ip)
         strSeries = f"{precision},".join(sensor_names) + precision
         url = (

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -25,6 +25,7 @@ class Iotawatt:
         username=None,
         password=None,
         integratedInterval="y",
+        includeNonTotalSensors="y"
     ):
         self._device_name = device_name
         self._ip = ip
@@ -32,6 +33,7 @@ class Iotawatt:
         self._username = username
         self._password = password
         self._integratedInterval = integratedInterval
+        self._includeNonTotalSensors = includeNonTotalSensors
         self._lastUpdateTime = None
 
         self._sensors = {}
@@ -140,15 +142,16 @@ class Iotawatt:
                 suffix=".wh",
                 fromStart=True,
             )
-            # self._createOrUpdateSensor(
-            #     sensors,
-            #     entity + "_energy",
-            #     channel_nbr,
-            #     base_name,
-            #     type,
-            #     "WattHours",
-            #     suffix=".wh",
-            # )
+            if self._includeNonTotalSensors:
+                self._createOrUpdateSensor(
+                    sensors,
+                    entity + "_energy",
+                    channel_nbr,
+                    base_name,
+                    type,
+                    "WattHours",
+                    suffix=".wh",
+                )
 
     async def _refreshSensors(self, timespan, lastUpdate):
         sensors = self._sensors["sensors"]


### PR DESCRIPTION
Remove energy sensors with fromStart=false: these are of limited use and trip up Home Assistant when inconsistent periods are used (sometimes 30s, sometimes 60s).

This change is fairly surgical, and doesn't remove the underlying fromStart functionality, which is now no longer used. This is to minimize diff with upstream, and in case the functionality is needed later.

See https://github.com/home-assistant/core/pull/104398 and https://github.com/home-assistant-libs/iotawattpy/issues/9