### PR TITLE
Make more sensible default for includeNonTotalSensors

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -25,7 +25,7 @@ class Iotawatt:
         username=None,
         password=None,
         integratedInterval="y",
-        includeNonTotalSensors="y"
+        includeNonTotalSensors=True
     ):
         self._device_name = device_name
         self._ip = ip


### PR DESCRIPTION
From https://github.com/home-assistant-libs/iotawattpy/pull/10/files
Dumb default value (my bad).