### PR TITLE
Handle empty query results in _refreshSensors

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -241,8 +241,9 @@ class Iotawatt:
         )
         values = response.json()
         LOGGER.debug("Val: %s", values)
-        for idx, entity in enumerate(current_query_entities):
-            sensors[entity].setValue(values[0][idx])
+        if values:
+            for idx, entity in enumerate(current_query_entities):
+                sensors[entity].setValue(values[0][idx])
 
         # Integrated measurements since the beginning of the period
         integrated_total_query_names = [
@@ -256,9 +257,13 @@ class Iotawatt:
         if integrate_response is not None:
             values = integrate_response.json()
             LOGGER.debug("Val: %s", values)
-            for idx, entity in enumerate(integrated_total_query_entities):
-                sensors[entity].setValue(values[0][idx + 1])
-                sensors[entity].setBegin(values[0][0])
+            # The result is empty when the queried interval is zero-length,
+            # e.g. right at the start of the integration period (midnight
+            # for "d"). Keep the previous values until the next update.
+            if values:
+                for idx, entity in enumerate(integrated_total_query_entities):
+                    sensors[entity].setValue(values[0][idx + 1])
+                    sensors[entity].setBegin(values[0][0])
 
         # Integrated measurements since the previous query
         integrated_query_names = [
@@ -300,9 +305,10 @@ class Iotawatt:
         if integrate_response is not None:
             values = integrate_response.json()
             LOGGER.debug("Val: %s", values)
-            for idx, entity in enumerate(integrated_query_entities):
-                sensors[entity].setValue(values[0][idx + 1])
-                sensors[entity].setBegin(values[0][0])
+            if values:
+                for idx, entity in enumerate(integrated_query_entities):
+                    sensors[entity].setValue(values[0][idx + 1])
+                    sensors[entity].setBegin(values[0][0])
 
         self._lastUpdateTime = now
 

--- a/tests/test_iotawatt_update.py
+++ b/tests/test_iotawatt_update.py
@@ -1,0 +1,86 @@
+"""Tests for Iotawatt.update() against a mocked device."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import respx
+
+from iotawattpy.iotawatt import Iotawatt
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+HOST = "192.0.2.1"
+
+STATUS_WIFI = {"wifi": {"mac": "de:ad:be:ef:00:01"}}
+STATUS_INPUTS_OUTPUTS = {
+    "inputs": [{"channel": 0, "Watts": "123"}],
+    "outputs": [],
+}
+SHOW_SERIES = {"series": [{"name": "Main", "unit": "Watts"}]}
+
+CURRENT_RESULT = [[123.4]]
+INTEGRATED_RESULT: list[list[str | float]] = [["2024-09-02T00:00:00", 4567]]
+
+
+@pytest.fixture
+async def websession() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient() as client:
+        yield client
+
+
+def _mock_device(integrated_result: list[list[str | float]]) -> None:
+    """Mock the device HTTP endpoints."""
+    respx.get(f"http://{HOST}/status", params={"wifi": "yes"}).respond(json=STATUS_WIFI)
+    respx.get(
+        f"http://{HOST}/status", params={"inputs": "yes", "outputs": "yes"}
+    ).respond(json=STATUS_INPUTS_OUTPUTS)
+
+    def query(request: httpx.Request) -> httpx.Response:
+        params = request.url.params
+        if params.get("show") == "series":
+            return httpx.Response(200, json=SHOW_SERIES)
+        if params["select"].startswith("[time.iso"):
+            return httpx.Response(200, json=integrated_result)
+        return httpx.Response(200, json=CURRENT_RESULT)
+
+    respx.get(f"http://{HOST}/query").mock(side_effect=query)
+
+
+@respx.mock
+async def test_update(websession: httpx.AsyncClient) -> None:
+    """A normal update populates current and integrated sensor values."""
+    _mock_device(INTEGRATED_RESULT)
+    iotawatt = Iotawatt(
+        "test", HOST, websession, integratedInterval="d", includeNonTotalSensors=False
+    )
+
+    await iotawatt.update()
+
+    sensors = iotawatt.getSensors()["sensors"]
+    assert sensors["input_0"].getValue() == 123.4
+    assert sensors["input_0_total_energy"].getValue() == 4567
+    assert sensors["input_0_total_energy"].getBegin() == "2024-09-02T00:00:00"
+
+
+@respx.mock
+async def test_update_empty_integrated_result(websession: httpx.AsyncClient) -> None:
+    """An empty integrated query result is skipped instead of raising.
+
+    The device returns [] for a zero-length interval, e.g. when queried
+    with begin=d within the first seconds after midnight.
+    """
+    _mock_device([])
+    iotawatt = Iotawatt(
+        "test", HOST, websession, integratedInterval="d", includeNonTotalSensors=False
+    )
+
+    await iotawatt.update()
+
+    sensors = iotawatt.getSensors()["sensors"]
+    assert sensors["input_0"].getValue() == 123.4
+    assert sensors["input_0_total_energy"].getValue() is None
+    assert sensors["input_0_total_energy"].getBegin() is None


### PR DESCRIPTION
The IoTaWatt query API returns an empty array for a zero-length interval. This happens for integrated queries with a relative begin time (e.g. begin=d used for day totals) when the device is queried within the first seconds of the period: at device-local midnight, begin=d and end=s both resolve to the same timestamp, and the firmware responds with []. Indexing values[0] then raised IndexError.

Skip updating the affected sensors when the result is empty; the next update cycle returns proper data again.

Fixes home-assistant/core#125038