### PR TITLE
Add release pipeline with automatic PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+---
+name: Release
+
+# yamllint disable-line rule:truthy
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v4
+      - name: 🏗 Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: 🏗 Set up Python
+        run: uv python install
+      - name: ✅ Verify version matches release tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(uv version --short)"
+          if [ "${tag}" != "${version}" ]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match" \
+              "project version ${version}" >&2
+            exit 1
+          fi
+      - name: 🚀 Build sdist and wheel
+        run: uv build
+      - name: 🧪 Install built wheel and import package
+        run: |
+          uv venv /tmp/install-test
+          uv pip install --python /tmp/install-test/bin/python dist/*.whl
+          /tmp/install-test/bin/python -c "import iotawattpy"
+      - name: ⬆️ Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: release
+      url: https://pypi.org/project/ha-iotawattpy/
+    permissions:
+      # Required for PyPI trusted publishing (OIDC)
+      id-token: write
+    steps:
+      - name: ⬇️ Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-![Python package](https://github.com/gtdiehl/iotawattpy/workflows/Python%20package/badge.svg)
+![CI](https://github.com/home-assistant-libs/iotawattpy/actions/workflows/ci.yml/badge.svg)
 
 # iotawattpy
  Python interface for the IoTaWatt device
+
+## Releasing
+
+Releases are published to [PyPI](https://pypi.org/project/ha-iotawattpy/)
+automatically when a GitHub release is published:
+
+1. Bump the version on `main`: `uv version <new-version>` (updates
+   `pyproject.toml` and `uv.lock`), then commit the change.
+2. Create a GitHub release with a `v<new-version>` tag (e.g. `v0.2.1`).
+3. The release workflow builds the package and uploads it to PyPI using
+   trusted publishing. It fails if the tag does not match the project
+   version.


### PR DESCRIPTION
## Summary

Add a release workflow that publishes to PyPI automatically when a GitHub release is published. The version bump remains a manual step.

- **Trusted publishing (OIDC)** via `pypa/gh-action-pypi-publish` — no API token secret to create or rotate, unlike the twine-based setup in older repos (e.g. python-otbr-api).
- **Tag/version guard**: the build fails if the release tag (e.g. `v0.2.1`) doesn't match the version in `pyproject.toml`, catching a forgotten bump before anything is uploaded.
- **Wheel smoke test**: the built wheel is installed into a fresh venv and imported before publishing.
- Publishing is gated behind a `release` GitHub environment, so required reviewers can be added later if desired.

Also documents the release process in the README (`uv version <new-version>` keeps `pyproject.toml` and `uv.lock` in sync, avoiding the 0.2.0 lockfile mismatch) and fixes the CI badge still pointing at the pre-fork gtdiehl repository.

## One-time setup required

On PyPI ([manage → publishing](https://pypi.org/manage/project/ha-iotawattpy/settings/publishing/)), add a GitHub trusted publisher:

| Field | Value |
|---|---|
| Owner | `home-assistant-libs` |
| Repository | `iotawattpy` |
| Workflow | `release.yml` |
| Environment | `release` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)