### PR TITLE
Add lifetime energy sensors

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -387,7 +387,10 @@ class Iotawatt:
         """Return the UNIX time of the oldest datalog record.
 
         Prefers the history log over the (shorter) current log. Returns 0
-        if the device does not report a usable datalog start.
+        if the device does not report a usable datalog start; firmware
+        without datalogs support responds 200 with the key absent.
+        Transport errors propagate like for any other device request so
+        the caller can retry with an accurate datalog start.
         """
         url = f"http://{self._ip}/status?datalogs=yes"
         response = await self._connection.get(url, self._username, self._password)

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -15,6 +15,11 @@ LOGGER = logging.getLogger(__name__)
 
 _HTTP_UNAUTHORIZED = 401
 _ROUND_SECONDS = 5
+# The device only parses UNIX times of exactly 10 digits (i.e. after
+# 2001-09-09). Earlier keys fall back to a date the device clamps to the
+# oldest datalog record.
+_MIN_DATALOG_KEY = 1_000_000_000
+_DATALOG_FALLBACK_BEGIN = "2000-01-01"
 
 
 class Iotawatt:
@@ -29,6 +34,7 @@ class Iotawatt:
         password: str | None = None,
         integratedInterval: str = "y",
         includeNonTotalSensors: bool = True,
+        includeLifetimeSensors: bool = False,
     ) -> None:
         """Initialize the device wrapper.
 
@@ -39,6 +45,9 @@ class Iotawatt:
         :param password: Optional digest-auth password.
         :param integratedInterval: Period for integrated WattHour queries.
         :param includeNonTotalSensors: Whether to add per-period energy sensors.
+        :param includeLifetimeSensors: Whether to add energy sensors integrating
+            since the start of the device datalog. These are monotonically
+            increasing meter readings independent of any reset period.
         """
         self._device_name = device_name
         self._ip = ip
@@ -47,7 +56,9 @@ class Iotawatt:
         self._password = password
         self._integratedInterval = integratedInterval
         self._includeNonTotalSensors = includeNonTotalSensors
+        self._includeLifetimeSensors = includeLifetimeSensors
         self._lastUpdateTime: datetime | None = None
+        self._datalogStart: int | None = None
 
         self._sensors: dict[str, dict[str, Sensor]] = {"sensors": {}}
 
@@ -114,6 +125,7 @@ class Iotawatt:
         unit: str,
         suffix: str | None = None,
         fromStart: bool = False,
+        lifetime: bool = False,
     ) -> None:
         """Create or update a single sensor entry."""
         if entity not in sensors:
@@ -128,6 +140,7 @@ class Iotawatt:
                 None,
                 self._macAddress,
                 fromStart,
+                lifetime,
             )
         else:
             sensor = sensors[entity]
@@ -136,6 +149,7 @@ class Iotawatt:
             sensor.setUnit(unit)
             sensor.setSensorID(self._macAddress)
             sensor.setFromStart(fromStart)
+            sensor.setLifetime(lifetime)
 
     def _createOrUpdateSensorSet(
         self,
@@ -172,6 +186,17 @@ class Iotawatt:
                     io_type,
                     "WattHours",
                     suffix=".wh",
+                )
+            if self._includeLifetimeSensors:
+                self._createOrUpdateSensor(
+                    sensors,
+                    entity + "_lifetime_energy",
+                    channel_nbr,
+                    base_name,
+                    io_type,
+                    "WattHours",
+                    suffix=".wh",
+                    lifetime=True,
                 )
 
     async def _refreshSensors(  # noqa: C901, PLR0912, PLR0915
@@ -222,13 +247,16 @@ class Iotawatt:
         current_query_entities: list[str] = []
         integrated_total_query_entities: list[str] = []
         integrated_query_entities: list[str] = []
+        lifetime_query_entities: list[str] = []
         for entity, sensor in sensors.items():
-            if sensor.getUnit() == "WattHours" and sensor.getFromStart():
-                integrated_total_query_entities.append(entity)
-            elif sensor.getUnit() == "WattHours":
-                integrated_query_entities.append(entity)
-            else:
+            if sensor.getUnit() != "WattHours":
                 current_query_entities.append(entity)
+            elif sensor.getLifetime():
+                lifetime_query_entities.append(entity)
+            elif sensor.getFromStart():
+                integrated_total_query_entities.append(entity)
+            else:
+                integrated_query_entities.append(entity)
 
         # Current (right-now) measurements
         current_query_names = [
@@ -264,6 +292,30 @@ class Iotawatt:
                 for idx, entity in enumerate(integrated_total_query_entities):
                     sensors[entity].setValue(values[0][idx + 1])
                     sensors[entity].setBegin(values[0][0])
+
+        # Lifetime measurements since the start of the device datalog
+        if lifetime_query_entities:
+            if self._datalogStart is None:
+                self._datalogStart = await self._getDataLogStart()
+            begin = (
+                str(self._datalogStart)
+                if self._datalogStart >= _MIN_DATALOG_KEY
+                else _DATALOG_FALLBACK_BEGIN
+            )
+            lifetime_query_names = [
+                sensors[entity].getSourceName() for entity in lifetime_query_entities
+            ]
+            LOGGER.debug("Sen: %s", lifetime_query_names)
+            integrate_response = await self._getQuerySelectSeriesIntegrate(
+                lifetime_query_names, begin, precision=".d3"
+            )
+            if integrate_response is not None:
+                values = integrate_response.json()
+                LOGGER.debug("Val: %s", values)
+                if values:
+                    for idx, entity in enumerate(lifetime_query_entities):
+                        sensors[entity].setValue(values[0][idx + 1])
+                        sensors[entity].setBegin(values[0][0])
 
         # Integrated measurements since the previous query
         integrated_query_names = [
@@ -324,6 +376,21 @@ class Iotawatt:
         for key in keys_to_remove:
             LOGGER.debug("Removing stale entity: %s", key)
             sensors.pop(key)
+
+    async def _getDataLogStart(self) -> int:
+        """Return the UNIX time of the oldest datalog record.
+
+        Prefers the history log over the (shorter) current log. Returns 0
+        if the device does not report a usable datalog start.
+        """
+        url = f"http://{self._ip}/status?datalogs=yes"
+        response = await self._connection.get(url, self._username, self._password)
+        response.raise_for_status()
+        logs = {log.get("id"): log for log in response.json().get("datalogs", [])}
+        for log_id in ("History", "Current"):
+            if (log := logs.get(log_id)) and log.get("firstkey"):
+                return int(log["firstkey"])
+        return 0
 
     async def _getQueryShowSeries(self) -> httpx.Response:
         """Fetch the available series from the device."""

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -35,6 +35,7 @@ class Iotawatt:
         integratedInterval: str = "y",
         includeNonTotalSensors: bool = True,
         includeLifetimeSensors: bool = False,
+        includeTotalSensors: bool = True,
     ) -> None:
         """Initialize the device wrapper.
 
@@ -48,6 +49,9 @@ class Iotawatt:
         :param includeLifetimeSensors: Whether to add energy sensors integrating
             since the start of the device datalog. These are monotonically
             increasing meter readings independent of any reset period.
+        :param includeTotalSensors: Whether to add energy sensors integrating
+            since the start of the current period (integratedInterval).
+            Disabling this also skips the corresponding device query.
         """
         self._device_name = device_name
         self._ip = ip
@@ -57,6 +61,7 @@ class Iotawatt:
         self._integratedInterval = integratedInterval
         self._includeNonTotalSensors = includeNonTotalSensors
         self._includeLifetimeSensors = includeLifetimeSensors
+        self._includeTotalSensors = includeTotalSensors
         self._lastUpdateTime: datetime | None = None
         self._datalogStart: int | None = None
 
@@ -167,16 +172,17 @@ class Iotawatt:
 
         # Also add Energy sensors (the integral of Power) for all Power sensors
         if unit == "Watts":
-            self._createOrUpdateSensor(
-                sensors,
-                entity + "_total_energy",
-                channel_nbr,
-                base_name,
-                io_type,
-                "WattHours",
-                suffix=".wh",
-                fromStart=True,
-            )
+            if self._includeTotalSensors:
+                self._createOrUpdateSensor(
+                    sensors,
+                    entity + "_total_energy",
+                    channel_nbr,
+                    base_name,
+                    io_type,
+                    "WattHours",
+                    suffix=".wh",
+                    fromStart=True,
+                )
             if self._includeNonTotalSensors:
                 self._createOrUpdateSensor(
                     sensors,

--- a/iotawattpy/sensor.py
+++ b/iotawattpy/sensor.py
@@ -31,13 +31,10 @@ class Sensor:
         self._unit = unit
         self._value: float | None = value
         self._begin: str | None = begin
-        self._sensor_id: str = ""
         self._fromStart = fromStart
         self._lifetime = lifetime
 
         self.hub_mac_address = mac_addr
-
-        self.setSensorID(mac_addr)
 
     def getChannel(self) -> str:
         """Return the channel identifier."""
@@ -48,12 +45,12 @@ class Sensor:
         self._channel = channel
 
     def getSensorID(self) -> str:
-        """Return the unique sensor ID."""
-        return self._sensor_id
+        """Return the sensor ID computed from the hub MAC and current name."""
+        return f"{self.hub_mac_address}_{self._type}_{self.getName()}"
 
     def setSensorID(self, hub_mac_address: str) -> None:
-        """Compute and set the sensor ID from the hub MAC and name."""
-        self._sensor_id = f"{hub_mac_address}_{self._type}_{self.getName()}"
+        """Set the hub MAC address the sensor ID is computed from."""
+        self.hub_mac_address = hub_mac_address
 
     def getSourceName(self) -> str:
         """Return the source name (base name + optional suffix)."""

--- a/iotawattpy/sensor.py
+++ b/iotawattpy/sensor.py
@@ -21,6 +21,7 @@ class Sensor:
         begin: str | None,
         mac_addr: str,
         fromStart: bool = False,
+        lifetime: bool = False,
     ) -> None:
         """Initialize the sensor."""
         self._channel = channel
@@ -32,6 +33,7 @@ class Sensor:
         self._begin: str | None = begin
         self._sensor_id: str = ""
         self._fromStart = fromStart
+        self._lifetime = lifetime
 
         self.hub_mac_address = mac_addr
 
@@ -59,6 +61,8 @@ class Sensor:
 
     def getName(self) -> str:
         """Return the display name for this sensor."""
+        if self._lifetime:
+            return self.getSourceName() + "_lifetime"
         return self.getSourceName() + (
             "_last" if self._suffix == ".wh" and not self._fromStart else ""
         )
@@ -118,3 +122,11 @@ class Sensor:
     def setFromStart(self, fromStart: bool) -> None:
         """Set whether the sensor reports values from the start of the period."""
         self._fromStart = fromStart
+
+    def getLifetime(self) -> bool:
+        """Return whether the sensor reports values since the start of the datalog."""
+        return self._lifetime
+
+    def setLifetime(self, lifetime: bool) -> None:
+        """Set whether the sensor reports values since the start of the datalog."""
+        self._lifetime = lifetime

--- a/tests/test_iotawatt_update.py
+++ b/tests/test_iotawatt_update.py
@@ -160,6 +160,29 @@ async def test_update_lifetime_datalog_start_cached(
     assert datalogs_route.call_count == 1
 
 
+@respx.mock
+async def test_update_lifetime_only(websession: httpx.AsyncClient) -> None:
+    """Without total sensors, the period query is not issued at all."""
+    integrated_queries = _mock_device(INTEGRATED_RESULT)
+    iotawatt = Iotawatt(
+        "test",
+        HOST,
+        websession,
+        integratedInterval="d",
+        includeNonTotalSensors=False,
+        includeLifetimeSensors=True,
+        includeTotalSensors=False,
+    )
+
+    await iotawatt.update()
+
+    sensors = iotawatt.getSensors()["sensors"]
+    assert "input_0_total_energy" not in sensors
+    assert sensors["input_0"].getValue() == 123.4
+    assert sensors["input_0_lifetime_energy"].getValue() == 12345678.912
+    assert [q["begin"] for q in integrated_queries] == ["1600000000"]
+
+
 @pytest.mark.parametrize(
     ("datalogs", "expected_begin"),
     [

--- a/tests/test_iotawatt_update.py
+++ b/tests/test_iotawatt_update.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import pytest
@@ -20,10 +20,17 @@ STATUS_INPUTS_OUTPUTS = {
     "inputs": [{"channel": 0, "Watts": "123"}],
     "outputs": [],
 }
+STATUS_DATALOGS = {
+    "datalogs": [
+        {"id": "Current", "firstkey": 1750000000, "lastkey": 1751000000},
+        {"id": "History", "firstkey": 1600000000, "lastkey": 1751000000},
+    ]
+}
 SHOW_SERIES = {"series": [{"name": "Main", "unit": "Watts"}]}
 
 CURRENT_RESULT = [[123.4]]
 INTEGRATED_RESULT: list[list[str | float]] = [["2024-09-02T00:00:00", 4567]]
+LIFETIME_RESULT: list[list[str | float]] = [["2020-09-13T14:26:40", 12345678.912]]
 
 
 @pytest.fixture
@@ -32,22 +39,38 @@ async def websession() -> AsyncIterator[httpx.AsyncClient]:
         yield client
 
 
-def _mock_device(integrated_result: list[list[str | float]]) -> None:
-    """Mock the device HTTP endpoints."""
+def _mock_device(
+    integrated_result: list[list[str | float]],
+    datalogs: dict[str, Any] = STATUS_DATALOGS,
+) -> list[dict[str, str]]:
+    """Mock the device HTTP endpoints.
+
+    Returns a list capturing the parameters of every integrated
+    (time.iso) query the library performs.
+    """
     respx.get(f"http://{HOST}/status", params={"wifi": "yes"}).respond(json=STATUS_WIFI)
     respx.get(
         f"http://{HOST}/status", params={"inputs": "yes", "outputs": "yes"}
     ).respond(json=STATUS_INPUTS_OUTPUTS)
+    respx.get(f"http://{HOST}/status", params={"datalogs": "yes"}).respond(
+        json=datalogs
+    )
+
+    integrated_queries: list[dict[str, str]] = []
 
     def query(request: httpx.Request) -> httpx.Response:
         params = request.url.params
         if params.get("show") == "series":
             return httpx.Response(200, json=SHOW_SERIES)
         if params["select"].startswith("[time.iso"):
-            return httpx.Response(200, json=integrated_result)
+            integrated_queries.append(dict(params))
+            if params["begin"] == "d":
+                return httpx.Response(200, json=integrated_result)
+            return httpx.Response(200, json=LIFETIME_RESULT)
         return httpx.Response(200, json=CURRENT_RESULT)
 
     respx.get(f"http://{HOST}/query").mock(side_effect=query)
+    return integrated_queries
 
 
 @respx.mock
@@ -64,6 +87,7 @@ async def test_update(websession: httpx.AsyncClient) -> None:
     assert sensors["input_0"].getValue() == 123.4
     assert sensors["input_0_total_energy"].getValue() == 4567
     assert sensors["input_0_total_energy"].getBegin() == "2024-09-02T00:00:00"
+    assert "input_0_lifetime_energy" not in sensors
 
 
 @respx.mock
@@ -84,3 +108,98 @@ async def test_update_empty_integrated_result(websession: httpx.AsyncClient) -> 
     assert sensors["input_0"].getValue() == 123.4
     assert sensors["input_0_total_energy"].getValue() is None
     assert sensors["input_0_total_energy"].getBegin() is None
+
+
+@respx.mock
+async def test_update_lifetime_sensors(websession: httpx.AsyncClient) -> None:
+    """Lifetime sensors integrate since the datalog start."""
+    integrated_queries = _mock_device(INTEGRATED_RESULT)
+    iotawatt = Iotawatt(
+        "test",
+        HOST,
+        websession,
+        integratedInterval="d",
+        includeNonTotalSensors=False,
+        includeLifetimeSensors=True,
+    )
+
+    await iotawatt.update()
+
+    sensors = iotawatt.getSensors()["sensors"]
+    sensor = sensors["input_0_lifetime_energy"]
+    assert sensor.getName() == "Main.wh_lifetime"
+    assert sensor.getLifetime() is True
+    assert sensor.getValue() == 12345678.912
+    assert sensor.getBegin() == "2020-09-13T14:26:40"
+    assert sensors["input_0_total_energy"].getValue() == 4567
+
+    lifetime_query = next(q for q in integrated_queries if q["begin"] != "d")
+    assert lifetime_query["begin"] == "1600000000"
+    assert "Main.wh.d3" in lifetime_query["select"]
+
+
+@respx.mock
+async def test_update_lifetime_datalog_start_cached(
+    websession: httpx.AsyncClient,
+) -> None:
+    """The datalog start is only fetched once across updates."""
+    _mock_device(INTEGRATED_RESULT)
+    iotawatt = Iotawatt(
+        "test",
+        HOST,
+        websession,
+        integratedInterval="d",
+        includeNonTotalSensors=False,
+        includeLifetimeSensors=True,
+    )
+
+    await iotawatt.update()
+    await iotawatt.update()
+
+    datalogs_route = respx.get(f"http://{HOST}/status", params={"datalogs": "yes"})
+    assert datalogs_route.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("datalogs", "expected_begin"),
+    [
+        pytest.param(STATUS_DATALOGS, "1600000000", id="prefer-history"),
+        pytest.param(
+            {
+                "datalogs": [
+                    {"id": "Current", "firstkey": 1750000000},
+                    {"id": "History", "firstkey": 0},
+                ]
+            },
+            "1750000000",
+            id="empty-history",
+        ),
+        pytest.param(
+            {"datalogs": [{"id": "Current", "firstkey": 999999999}]},
+            "2000-01-01",
+            id="clock-not-set",
+        ),
+        pytest.param({"datalogs": []}, "2000-01-01", id="no-datalogs"),
+    ],
+)
+@respx.mock
+async def test_update_lifetime_begin_selection(
+    websession: httpx.AsyncClient,
+    datalogs: dict[str, Any],
+    expected_begin: str,
+) -> None:
+    """The lifetime query begin is derived from the datalog status."""
+    integrated_queries = _mock_device(INTEGRATED_RESULT, datalogs=datalogs)
+    iotawatt = Iotawatt(
+        "test",
+        HOST,
+        websession,
+        integratedInterval="d",
+        includeNonTotalSensors=False,
+        includeLifetimeSensors=True,
+    )
+
+    await iotawatt.update()
+
+    lifetime_query = next(q for q in integrated_queries if q["begin"] != "d")
+    assert lifetime_query["begin"] == expected_begin

--- a/tests/test_iotawatt_update.py
+++ b/tests/test_iotawatt_update.py
@@ -41,13 +41,15 @@ async def websession() -> AsyncIterator[httpx.AsyncClient]:
 
 def _mock_device(
     integrated_result: list[list[str | float]],
-    datalogs: dict[str, Any] = STATUS_DATALOGS,
+    datalogs: dict[str, Any] | None = None,
 ) -> list[dict[str, str]]:
     """Mock the device HTTP endpoints.
 
     Returns a list capturing the parameters of every integrated
     (time.iso) query the library performs.
     """
+    if datalogs is None:
+        datalogs = STATUS_DATALOGS
     respx.get(f"http://{HOST}/status", params={"wifi": "yes"}).respond(json=STATUS_WIFI)
     respx.get(
         f"http://{HOST}/status", params={"inputs": "yes", "outputs": "yes"}
@@ -203,6 +205,7 @@ async def test_update_lifetime_only(websession: httpx.AsyncClient) -> None:
             id="clock-not-set",
         ),
         pytest.param({"datalogs": []}, "2000-01-01", id="no-datalogs"),
+        pytest.param({}, "2000-01-01", id="firmware-without-datalogs-support"),
     ],
 )
 @respx.mock

--- a/tests/test_sensorio_getset.py
+++ b/tests/test_sensorio_getset.py
@@ -14,3 +14,22 @@ def sensor() -> Sensor:
 
 def test_get_name(sensor: Sensor) -> None:
     assert sensor.getName() == "myname"
+
+
+def test_sensor_id_reflects_mutations(sensor: Sensor) -> None:
+    """The sensor ID stays consistent with name-affecting mutations."""
+    assert sensor.getSensorID() == "deadbeef_Input_myname"
+
+    sensor.setSuffix(".wh")
+    sensor.setLifetime(True)
+    assert sensor.getSensorID() == "deadbeef_Input_myname.wh_lifetime"
+
+    sensor.setLifetime(False)
+    assert sensor.getSensorID() == "deadbeef_Input_myname.wh_last"
+
+    sensor.setFromStart(True)
+    assert sensor.getSensorID() == "deadbeef_Input_myname.wh"
+
+    sensor.setSensorID("cafe0001")
+    assert sensor.getSensorID() == "cafe0001_Input_myname.wh"
+    assert sensor.hub_mac_address == "cafe0001"


### PR DESCRIPTION
## Summary

Add opt-in lifetime energy sensors (`includeLifetimeSensors`, default off): for every power channel, a sensor reporting energy integrated **since the start of the device datalog** — a monotonically increasing meter reading, queried as

```
/query?select=[time.iso,<name>.wh.d3,...]&begin=<datalog firstkey>&end=s&group=all
```

The datalog start is read once from `/status?datalogs=yes`, preferring the History log over the shorter Current log ([webServer.cpp#L638-L657](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/webServer.cpp#L638-L657)).

New sensor keys are `input_N_lifetime_energy` / `output_X_lifetime_energy`, named `<name>.wh_lifetime` following the existing `_last` suffix convention. `getBegin()` carries the datalog start ("metering since"). With the flag off (default), behavior is byte-for-byte unchanged — consumers can bump without side effects and opt in explicitly.

## Why this is more robust than the period sensors (with firmware receipts)

The existing "total" sensors query `begin=<period>&end=s&group=all` (e.g. `begin=d` for day totals as used by Home Assistant). That interval is **legitimately zero-length once per period**: for the first ~5 s after device-local midnight, `d` and `s` resolve to the same timestamp ([CSVquery.cpp#L853-L869](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/CSVquery.cpp#L853-L869) — `s` rounds down to 5 s, `d` truncates to local midnight). The firmware accepts `begin == end` (only `end < begin` is rejected, [CSVquery.cpp#L56-L64](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/CSVquery.cpp#L56-L64)) and then immediately closes the result array, returning `[]` ([CSVquery.cpp#L631-L648](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/CSVquery.cpp#L631-L648)). That is the root cause of home-assistant/core#125038, worked around defensively in #18.

Lifetime sensors eliminate that failure class instead of guarding it:

- **The interval can never be zero-length** — `begin` is a fixed past key, `end=s` is now.
- **No period semantics** — no `last_reset`, and no dependency on the device's local timezone on the client side (the period sensors reset at *device-local* midnight, which the client cannot know).
- **Values survive client downtime** — the accumulation happens on the device; a consumer computing deltas (e.g. HA long-term statistics) loses nothing across restarts, unlike a daily-reset value where downtime spanning midnight drops the pre-midnight remainder.
- **Cheap for the device** — `group=all` is just two keyed datalog reads, not a scan: the query engine ages one record and reads the group-end record ([CSVquery.cpp#L650-L667](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/CSVquery.cpp#L650-L667)); energy comes from the cumulative accumulators stored in each log record.
- **Self-healing bounds** — a `begin` before the oldest record is clamped to the first record by the log layer ([IotaLog.cpp#L119-L137](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/IotaLog.cpp#L119-L137)), so a stale cached start key or a rotated log degrades gracefully.

One firmware quirk handled explicitly: the time parser only accepts UNIX times of **exactly 10 digits** ([CSVquery.cpp#L802-L812](https://github.com/boblemaire/IoTaWatt/blob/90c12bb2887030c91372493bb3306ec12e3d5702/Firmware/IotaWatt/CSVquery.cpp#L802-L812)). A `firstkey` before 2001-09-09 (device clock never set) or a missing datalogs response falls back to `begin=2000-01-01`, which the clamping above resolves to the oldest record.

## Verified against real hardware

```
$ curl "http://iotawatt/status?datalogs=yes"
{"datalogs":[{"id":"Current","firstkey":1753127705,...,"interval":5},
             {"id":"History","firstkey":1689857520,...,"interval":60}]}

$ curl "http://iotawatt/query?select=[time.iso,total_power.wh.d3,Phase1.wh.d3]&begin=1689857520&end=s&group=all"
[["2023-07-20T12:52:00",8829387.51,5146022.279]]
```

Sub-second response for a 3-year integration window.

## Testing

- 9 tests, incl. lifetime value/naming, datalog-start caching across updates, parametrized begin selection (prefer-history / empty-history / clock-not-set / no-datalogs), and default-off behavior.
- Intended consumer: home-assistant/core iotawatt integration (`TOTAL_INCREASING` energy sensors replacing the day-total ones — deprecation plan handled on the core side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)